### PR TITLE
Use simplejson if it is available.

### DIFF
--- a/phpy/php.py
+++ b/phpy/php.py
@@ -1,5 +1,8 @@
+try:
+    import simplejson as json
+except ImportError:
+    import json
 from subprocess import Popen, PIPE
-import json
 from exceptions import *
 
 


### PR DESCRIPTION
[simplejson](http://simplejson.readthedocs.org/en/latest/) is a drop-in replacement for `json` library. It's API is compatible with `json` and may will give us a performance advantages if use it.

So I updated the code to use `simplejson` if it has installed.

---

Environment _with_ `simplejson`:

``` pycon
>>> import phpy
>>> phpy.php
<module 'phpy.php' from 'phpy/php.pyc'>
>>> phpy.php.json
<module 'simplejson' from '/Users/yoloseem/.virtualenvs/ss/lib/python2.7/site-packages/simplejson-3.3.1-py2.7-macosx-10.9-x86_64.egg/simplejson/__init__.pyc'>
```

Environment _without_ `simplejson`:

``` pycon
>>> import phpy.php
>>> phpy.php.json
<module 'json' from '/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.pyc'>
```
