### PR TITLE
Single quote escaping

### DIFF
--- a/phpy/php.py
+++ b/phpy/php.py
@@ -10,12 +10,15 @@ class PHP:
     def __init__(self, file_path):
         self.file_path = file_path
 
+    def __escape(self, string):
+        return string.replace('\\', '\\\\').replace("'", "\\'")
+
     def __quote(self, arguments):
         for arg in arguments:
             if isinstance(arg, basestring):
                 if isinstance(arg, unicode):
                     arg = arg.encode('utf-8')
-                yield '\'%s\'' % arg
+                yield '\'%s\'' % self.__escape(arg)
             elif arg is None:
                 yield 'NULL'
             else:
@@ -32,7 +35,7 @@ class PHP:
             raise InvalidType
         p = Popen('php', stdin=PIPE, stdout=PIPE, stderr=PIPE)
         print >>p.stdin, '<?php '
-        print >>p.stdin, 'include \'%s\';' % self.file_path
+        print >>p.stdin, 'include \'%s\';' % self.__escape(self.file_path)
         print >>p.stdin, '%s(%s);' % (function_name,
                                     self.__join_arguments(arguments))
         p.stdin.close()

--- a/tests/test_phpy.py
+++ b/tests/test_phpy.py
@@ -12,6 +12,7 @@ test_php_path = os.path.join(os.path.dirname(__file__), 'test.php')
     (0.0, 1.1, 2.2),
     ('foo', 'bar', 'baz'),
     (u'가', u'나', u'다'),
+    ("'test' is important", "\\bar", "\\'baz"),
     (None, None, None),
 ])
 def test_get_dict(foo, bar, baz):


### PR DESCRIPTION
If python passes filepath or arguments has single quote, phpy makes error. This pull request fixes it.
